### PR TITLE
fixed typo that caused (bake upgrade) to fail

### DIFF
--- a/src/setup.c
+++ b/src/setup.c
@@ -65,9 +65,9 @@ int16_t bake_create_script(void)
 
     fprintf(f, "build_bake() {\n");
     fprintf(f, "    if [ \"$UNAME\" = \"Linux\" ]; then\n");
-    fprintf(f, "        make -C build-linux\n");
+    fprintf(f, "        make -C build-Linux\n");
     fprintf(f, "    elif [ \"$UNAME\" = \"Darwin\" ]; then\n");
-    fprintf(f, "        make -C build-darwin\n");
+    fprintf(f, "        make -C build-Darwin\n");
     fprintf(f, "    fi\n");
     fprintf(f, "}\n\n");
 


### PR DESCRIPTION
The script in `/usr/local/bin/bake` was referring to `/build-linux` and `/build-darwin` and the `bake upgrade` command was saying `no such file or directory` since the actual folder name is capital L and D   
There are also the same two folders with lower case in `/util` `driver/lang/c` and `driver/lang/cpp` along with `run_premake.sh` files refering to the lower case folders .. should we change all of them to uppercase??