### PR TITLE
Added sfml2 library

### DIFF
--- a/libraries/sfml2/include/sfml2.h
+++ b/libraries/sfml2/include/sfml2.h
@@ -1,0 +1,1 @@
+#include <SFML/Graphics.hpp>

--- a/libraries/sfml2/project.json
+++ b/libraries/sfml2/project.json
@@ -1,0 +1,12 @@
+{
+    "id": "sfml2",
+    "type": "package",
+    "value": {
+        "language": "none"
+    },
+    "dependee": {
+        "lang.$${language}": {
+            "lib": ["sfml-graphics","sfml-window","sfml-audio","sfml-network","sfml-system","stdc++","GL","X11"]
+        }
+    }
+}


### PR DESCRIPTION
This is the dynamic linking of sfml2 library, i tested it for all the examples on https://github.com/SFML/SFML/tree/master/examples and all the ones except (the ones made for phones or windows) worked by pasting a file named `project.json` with this content    
```
{
    "id": "name",
    "type": "application",
    "value": {
        "language": "c++",
	"use": ["sfml2"]
    }
}
```
and creating a folder called `src` and moving the source files to it then `bake` and `bake run`   
it links to `GL` which is `opengl32` for windows, and `X11` which is not for windows, not sure for mac since i never used it   
static linking requires more work that i don't want to do   
    
Is there any way i could make comments for these? because json doesn't support comments .. we could either make a file in the folder called `Notes.txt` or something like that, or make something in the json file like `"comment":"put your comment here"` and the bake program should ignore it