### PR TITLE
Windows build hot fixes

### DIFF
--- a/util/include/util.h
+++ b/util/include/util.h
@@ -64,6 +64,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <versionhelpers.h>
+#include <shlwapi.h>
 #else
 #include <fnmatch.h>
 #include <inttypes.h>


### PR DESCRIPTION
* Fixed linker error due to the missing header file inclusion:
```
Linking bake
   Creating library ..\bake.lib and object ..\bake.exp
fs.obj : error LNK2019: unresolved external symbol _PathIsDirectoryA referenced in function _ut_isdir
fs.obj : error LNK2019: unresolved external symbol _PathFileExistsA referenced in function _ut_opendir
expr.obj : error LNK2019: unresolved external symbol _PathMatchSpecA referenced in function _ut_expr_runExpr
..\bake.exe : fatal error LNK1120: 3 unresolved externals
```