### PR TITLE
[Questionable] Missing msvc linker flag

### DIFF
--- a/drivers/lang/c/src/msvc/driver.c
+++ b/drivers/lang/c/src/msvc/driver.c
@@ -22,7 +22,7 @@
 #include <bake.h>
 
 static
-char* obj_ext() 
+char* obj_ext()
 {
     return ".obj";
 }
@@ -226,7 +226,7 @@ void link_dynamic_binary(
     bool export_symbols = driver->get_attr_bool("export-symbols");
 
     ut_strbuf_append(&cmd, "link");
-    
+
     /* Suppress Visual C++ banner */
     ut_strbuf_appendstr(&cmd, " /NOLOGO");
 
@@ -238,6 +238,11 @@ void link_dynamic_binary(
         }
 
         ut_strbuf_appendstr(&cmd, " /DYNAMICBASE:NO /NXCOMPAT:NO /DLL");
+
+        char *implib_file = strdup(target);
+        char *ext = strrchr(implib_file, '.');
+        strcpy(ext + 1, "lib");
+        ut_strbuf_append(&cmd, " /IMPLIB:\"%s\"", implib_file);
 
     }
 


### PR DESCRIPTION
Fix: To force generate a dll import lib, we need to pass /IMPLIB

### **_Important Caveat!!!_** 
This no longer seems to be work on MSVC 2019 16.5.4 It may not be worth merging this unless other users express problems. I haven't tested it on any other windows + msvc combination other than msvc 16.5.4 + win10 sdk 1903