### PR TITLE
Fixing is_clang wrongly returning false on macOS

### DIFF
--- a/drivers/lang/c/src/gcc/driver.c
+++ b/drivers/lang/c/src/gcc/driver.c
@@ -68,10 +68,15 @@ const char *cc(
 static
 bool is_clang(bool is_cpp)
 {
-    if (!strncmp(cc(is_cpp), "clang", 5)) {
-        return true;
+    bool matches_clang = false;
+    char *compiler = ut_strdup(cc(is_cpp));
+    char *token = strtok(compiler, UT_OS_PS);
+    while (token) {
+        matches_clang = (strncmp(token, "clang", 5) == 0);
+        token = strtok(NULL, UT_OS_PS);
     }
-    return false;
+    free(compiler);
+    return matches_clang;
 }
 
 static

--- a/drivers/lang/c/src/gcc/driver.c
+++ b/drivers/lang/c/src/gcc/driver.c
@@ -68,15 +68,19 @@ const char *cc(
 static
 bool is_clang(bool is_cpp)
 {
-    bool matches_clang = false;
-    char *compiler = ut_strdup(cc(is_cpp));
-    char *token = strtok(compiler, UT_OS_PS);
-    while (token) {
-        matches_clang = (strncmp(token, "clang", 5) == 0);
-        token = strtok(NULL, UT_OS_PS);
+    const char *compiler = cc(is_cpp);
+
+    /* First test if user is running clang from a non-standard path. */
+    const char path_separator = UT_OS_PS[0];
+    const char *cc_command = strrchr(compiler, path_separator);
+
+    if (cc_command && !strncmp(cc_command, UT_OS_PS "clang", 5)) {
+        return true;
+    } else if (!cc_command && !strncmp(compiler, "clang", 5)) {
+        return true;
+    } else {
+        return false;
     }
-    free(compiler);
-    return matches_clang;
 }
 
 static


### PR DESCRIPTION
is_clang returns ‘false’ if cc() returns a full path to the clang executable (e.g., CC=$(xcrun --find clang), causing the driver function cc() to return “/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang”).

This fix does the same comparison as before, but on the token at the end of the full path.