### PR TITLE
Consolidating duplicate `BAKE_ARCHITECTURE` environment variable

### DIFF
--- a/util/src/load.c
+++ b/util/src/load.c
@@ -1060,7 +1060,7 @@ int16_t ut_load_init(
     ut_setenv("BAKE_HOME", UT_HOME_PATH);
     ut_setenv("BAKE_TARGET", UT_TARGET_PATH);
     ut_setenv("BAKE_CONFIG", config);
-    ut_setenv("BAKE_ARCH", UT_ARCH);
+    ut_setenv("BAKE_ARCHITECTURE", UT_ARCH);
     ut_setenv("BAKE_OS", UT_OS);
     ut_setenv("BAKE_PLATFORM", UT_PLATFORM);
 


### PR DESCRIPTION
For issue #70 🙂

If a user doesn’t specify an architecture via the BAKE_ARCHITECTURE environment variable, save the default value in the same variable rather than the duplicate BAKE_ARCH var. This behaviour is consistent with the other environment variables used by Bake.

If backwards compatibility is a concern, I can tweak this PR to keep `BAKE_ARCH` as a duplicate.