### PR TITLE
#76 added check-symbols to package driver C option

### DIFF
--- a/drivers/lang/c/README.md
+++ b/drivers/lang/c/README.md
@@ -16,6 +16,7 @@ libpath | list[string] | Linker library path
 link | list[string] | List of objects and (static) library files to provide to the linker.
 include | list[string] | List of paths to look for include files
 static | bool | Create static library (packages only, default=false)
+check-symbols | bool | Check symbols presence (packages only, default=true)
 c-standard | string | Specify C standard (default=c99)
 cpp-standard | string | Specify C++ standard (default=c++0x)
 export-symbols | bool | Export all library symbols (default=false)

--- a/drivers/lang/c/src/gcc/driver.c
+++ b/drivers/lang/c/src/gcc/driver.c
@@ -518,6 +518,7 @@ void link_dynamic_binary(
     if (project->type == BAKE_PACKAGE) {
         /* Set symbol visibility */
         bool export_symbols = driver->get_attr_bool("export-symbols");
+        bool check_symbols = driver->get_attr_bool("check-symbols");
         if (!export_symbols) {
             ut_strbuf_appendstr(&cmd, " -fvisibility=hidden");
             hide_symbols = true;
@@ -526,7 +527,7 @@ void link_dynamic_binary(
         ut_strbuf_appendstr(&cmd, " -fno-stack-protector --shared");
 
         /* Fail when symbols are not found in library */
-        if (!is_clang(cpp)) {
+        if (!is_clang(cpp) && check_symbols) {
             ut_strbuf_appendstr(&cmd, " -z defs");
         }
     }

--- a/drivers/lang/c/src/main.c
+++ b/drivers/lang/c/src/main.c
@@ -121,6 +121,9 @@ void init(
         driver->set_attr_array("cxxflags", value);
         free(value);
     }
+    if (!driver->get_attr("check_symbols")) {
+        driver->set_attr_bool("check_symbols", true);
+    }
 
     if (!driver->get_attr("export-symbols")) {
         driver->set_attr_bool("export-symbols", false);

--- a/drivers/lang/c/src/msvc/driver.c
+++ b/drivers/lang/c/src/msvc/driver.c
@@ -250,6 +250,7 @@ void link_dynamic_binary(
 
     bool cpp = is_cpp(project);
     bool export_symbols = driver->get_attr_bool("export-symbols");
+    bool check_symbols = driver->get_attr_bool("check-symbols");
 
     ut_strbuf_append(&cmd, "link");
     

--- a/include/bake/config.h
+++ b/include/bake/config.h
@@ -57,6 +57,7 @@ struct bake_config {
     bool coverage;              /* Enable code coverage in binaries */
     bool strict;                /* Enable strict compiler settings */
     bool static_lib;            /* Enable static linking */
+    bool check_symbols;         /* Enable check symbols */
     bool sanitize_memory;       /* Enable memory sanitizer (if supported) */
     bool sanitize_thread;       /* Enable thread sanitizer (if supported) */
     bool sanitize_undefined;    /* Enable UB sanitizier (if supported) */

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,7 @@ const char *id = NULL;
 bake_project_type type = BAKE_APPLICATION;
 bool private = false;
 bool static_lib = false;
+bool check_symbols = true;
 const char *artefact = NULL;
 const char *includes = NULL;
 const char *language = NULL;
@@ -1387,7 +1388,8 @@ int main(int argc, const char *argv[]) {
         .optimizations = false,
         .coverage = false,
         .strict = false,
-        .static_lib = false
+        .static_lib = false,
+        .check_symbols = true
     };
 
     ut_tls_set(BAKE_CONFIG_KEY, &config);

--- a/util/src/load.c
+++ b/util/src/load.c
@@ -52,7 +52,6 @@ char *UT_STATIC_LIB_EXT;
 char *UT_EXECUTABLE_EXT;
 char *UT_BIN_EXT;
 char *UT_LIB_EXT;
-char *UT_STATIC_LIB_EXT;
 char *UT_LIB_PREFIX;
 
 /* Lock protecting the package administration */
@@ -63,6 +62,7 @@ struct ut_loaded {
 
     char *lib; /* Path to library (if available) */
     char *static_lib; /* Path to static library (if available) */
+    char *check_symbols; /* Set to false to avoid check library symbols */
     char *app; /* Path to executable (if available) */
     char *bin; /* Path to binary (if available) */
     char *etc; /* Path to project etc (if available) */
@@ -632,6 +632,7 @@ void ut_locate_reset(
             loaded->app = NULL;
             loaded->lib = NULL;
             loaded->static_lib = NULL;
+            loaded->check_symbols = NULL;
 
             loaded->tried_binary = false;
             loaded->tried_locating = false;
@@ -1053,7 +1054,6 @@ int16_t ut_load_init(
     UT_LIB_PREFIX = UT_OS_LIB_PREFIX;
     UT_BIN_EXT = UT_OS_BIN_EXT;
     UT_LIB_EXT = UT_OS_LIB_EXT;
-    UT_STATIC_LIB_EXT = UT_OS_STATIC_LIB_EXT;
     UT_LIB_PREFIX = UT_OS_LIB_PREFIX;
 
     /* Set environment variables */


### PR DESCRIPTION
* updated bake C driver to support new check-symbols option
* updated driver C README to include a new option check-symbols

Example:
```json
{
    "id": "com.7kas.pgpkg",
    "type": "package",
    "value": {
        "author": "John Doe",
        "description": "Premium coffee beans for kids"
    },
    "lang.c": {
        "include": ["/usr/include/postgresql/12/server"],
        "check-symbols": false
    }
}
```