### PR TITLE
docs: fix simple typo, untill -> until

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bake setup
 ```
 On Windows, make sure to open a **visual studio command prompt**, as you will need access to the visual studio build tools. After bake is installed, you can invoke bake from any command prompt. If you want to install bake for all users, open the command prompt as administrator.
 
-Bake installs a script to a location that is accessible for all users (`C:\Windows\System32` on Windows or `/usr/local/bin` on Linux). This however often requires administrator or root privileges. If you do not want bake to install this script and you get a password prompt, just press Enter untill the setup resumes.
+Bake installs a script to a location that is accessible for all users (`C:\Windows\System32` on Windows or `/usr/local/bin` on Linux). This however often requires administrator or root privileges. If you do not want bake to install this script and you get a password prompt, just press Enter until the setup resumes.
  
 In case you did not install bake for all users, you need to manually add `$HOME/bake` (`%USERPROFILE%\bake` on Windows) to your `PATH` environment variable. You can do this on a command prompt by doing:
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `until` rather than `untill`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md