### PR TITLE
Fix amalgamate on windows

### DIFF
--- a/drivers/amalgamate/src/main.c
+++ b/drivers/amalgamate/src/main.c
@@ -81,7 +81,7 @@ int amalgamate(
     time_t *last_modified,
     bool *main_included) 
 {
-    char *file = ut_strdup(const_file);
+    char *file = strreplace(const_file, "/", UT_OS_PS);
     ut_path_clean(file, file);
     if (ut_rb_find(files_parsed, file)) {
         ut_debug("amalgamate: skip   '%s'  (from '%s:%d')", file, 
@@ -97,7 +97,7 @@ int amalgamate(
 
     /* Get current path from filename (for relative includes) */
     char *cur_path = ut_strdup(file);
-    char *last_elem = strrchr(cur_path, '/');
+    char *last_elem = strrchr(cur_path, UT_OS_PS[0]);
     if (last_elem) {
         *last_elem = '\0';
         last_elem ++;

--- a/drivers/amalgamate/src/main.c
+++ b/drivers/amalgamate/src/main.c
@@ -114,7 +114,7 @@ int amalgamate(
     int32_t line_count = 0;
 
     /* Open file for reading */
-    FILE* in = fopen(file, "r");
+    FILE* in = ut_file_open(file, "r");
     if (!in) {
         ut_error("cannot read file '%s'", file);
         goto error;
@@ -222,7 +222,7 @@ int amalgamate(
 
     fprintf(out, "\n"); /* Support for empty files */
 
-    fclose(in);
+    ut_file_close(in);
 
     return 0;
 error:

--- a/src/project.c
+++ b/src/project.c
@@ -877,13 +877,10 @@ int16_t bake_project_init(
         bake_project_init_artefact(config, project);
     }
 
-    /* Amalgamate driver isn't working correctly on Windows yet */
-#ifndef UT_OS_WINDOWS
     if (project->amalgamate) {
         ut_try( bake_project_load_driver(
             project, "amalgamate", NULL), "failed to load amalgamate driver");        
     }
-#endif
 
     project->bin_path = ut_asprintf(
         "%s"UT_OS_PS"bin", project->path);

--- a/src/setup.c
+++ b/src/setup.c
@@ -146,36 +146,8 @@ int16_t bake_create_script(bool local, bool nopass)
     fprintf(f, ")\n\n");
     fclose(f);
 
-    char *script_path = ut_envparse(BAKE_SCRIPT_PATH);
-    if (!script_path) {
-        ut_error("failed to open '%s'", BAKE_SCRIPT_PATH);
-    }
-
-    if (!local) {
-        const char *path = ut_getenv("BAKE_USERPATH");
-        if (!path || !strstr(path, script_path)) {
-            ut_trace("add bake directory to user PATH");
-            char *path_w_bake = ut_asprintf("%s;%s", path, script_path);
-            f = fopen("export_bake.bat", "w");
-            if (!f) {
-                ut_throw("failed to create export script");
-                goto error;
-            }
-            fprintf(f, "@echo on\n");
-            fprintf(f, "setx PATH \"%s\"\n", path_w_bake);
-            fclose(f);
-
-            ut_try(cmd("export_bake.bat"), "failed to run export script");
-
-            ut_try(ut_rm("export_bake.bat"), "failed to remove export script");
-        } else {
-            bake_in_path = true;
-        }
-    }
-
     free(vc_shell_cmd);
     free(script_file_path);
-    free(script_path);
 
     return 0;
 error:

--- a/util/include/bake-util/file.h
+++ b/util/include/bake-util/file.h
@@ -43,6 +43,15 @@ FILE* ut_file_open(
     const char* file,
     const char* mode);
 
+/** Close a file stream.
+ *
+ * @param file The file stream to close.
+ * @return 0 if success, non-zero if failed.
+ */
+UT_API
+int ut_file_close(
+    FILE* file);
+
 /** Load contents of text file in memory.
  *
  * @param file The file to load.

--- a/util/src/file.c
+++ b/util/src/file.c
@@ -58,6 +58,12 @@ error:
     return NULL;
 }
 
+int ut_file_close(
+    FILE* file)
+{
+    return fclose(file);
+}
+
 char* ut_file_load(
     const char* filename)
 {


### PR DESCRIPTION
**Change Log**
- Fix crash caused by passing `FILE*` across DLL boundaries on windows when calling `ut_file_readln` from amalgamate. To fix this I replaced `fopen`/`fclose` with `ut_file_open`/`ut_file_close` so that bake util is the only thing interacting with the `FILE*` passed to `ut_file_readln`.
- Made amalgamate normalize file paths using `UT_OS_PS` so they are always consistent when added to `files_parsed` and when getting the current directory from the file path on windows.

**Known Bugs**
- ~~Currently bake amalgamate iterates files only using the order returned by the file system, this leads to inconsistent ordering when used on different file systems. To fix this the file paths need to be sorted so they are always processed in the same order. Because of this I've left amalgamate disabled on windows but this is likely to affect other environments as well.~~