### PR TITLE
Fix Windows include path handling

### DIFF
--- a/drivers/lang/c/src/msvc/driver.c
+++ b/drivers/lang/c/src/msvc/driver.c
@@ -174,7 +174,7 @@ void compile_src(
             bake_attr *include = ut_iter_next(&it);
             char* file = include->is.string;
 
-            if (file[0] == '/' || file[0] == '$') {
+            if (file[0] == '/' || file[0] == '$' || file[0] == '\\' || (file[0] != 0 && file[1] == ':')) {
                 ut_strbuf_append(&cmd, " /I%s", file);
             } else {
                 ut_strbuf_append(&cmd, " /I%s\\%s", project->path, file);


### PR DESCRIPTION
Before that absolute Windows path (and most likely [other "weird" win paths too](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats)) were prefixed with the current folder path, leading to incorrect includes.