### PR TITLE
Add %VAR% handling, add space before /I for clarity

### DIFF
--- a/drivers/lang/c/src/msvc/driver.c
+++ b/drivers/lang/c/src/msvc/driver.c
@@ -174,10 +174,10 @@ void compile_src(
             bake_attr *include = ut_iter_next(&it);
             char* file = include->is.string;
 
-            if (file[0] == '/' || file[0] == '$' || file[0] == '\\' || (file[0] != 0 && file[1] == ':')) {
-                ut_strbuf_append(&cmd, " /I%s", file);
+            if (file[0] == '/' || file[0] == '$' || file[0] == '%' || file[0] == '\\' || (file[0] != 0 && file[1] == ':')) {
+                ut_strbuf_append(&cmd, " /I %s", file);
             } else {
-                ut_strbuf_append(&cmd, " /I%s\\%s", project->path, file);
+                ut_strbuf_append(&cmd, " /I %s\\%s", project->path, file);
             }
         }
     }


### PR DESCRIPTION
I tested and stuff like `cl.exe /nologo ... /I %USERPROFILE%\bake\include /I .\include ... main.cpp` works fine, so Bake should support it too, also the lack of space between `/I` and the path was bugging me too.