### PR TITLE
feat: add support for visual studio build tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ git clone https://github.com/SanderMertens/bake
 bake/setup.sh
 ```
 
-On Windows (requires `C++ CMake tools for Windows` individual component included in the `Desktop development with C++` workload for Visual Studio):
+On Windows:
+
+Requires [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) or the full Visual Studio Community IDE installed with the `C++ CMake tools for Windows` and `Windows SDK` individual components included in the `Desktop development with C++` workload:
 ```
 git clone https://github.com/SanderMertens/bake
 cd bake

--- a/setup.bat
+++ b/setup.bat
@@ -30,6 +30,17 @@ if "%VSDIR%"=="" (
     )
 )
 
+rem If not found, find visual studio cli build tools installation
+if "%VSDIR%"=="" (
+    for /l %%v in (2050, -1, 2019) do (
+        if "%VSDIR%"=="" (
+          if exist "C:\Program Files (x86)\Microsoft Visual Studio\%%v\BuildTools\" (
+              set VSDIR=C:\Program Files (x86^)\Microsoft Visual Studio\%%v\BuildTools
+          )
+        )
+    )
+)
+
 if "%VSDIR%"=="" (
     echo No visual studio installation found! Try running again in visual studio prompt.
     goto :eof

--- a/setup.bat
+++ b/setup.bat
@@ -23,7 +23,7 @@ rem If not found, try in x86 program files
 if "%VSDIR%"=="" (
     for /l %%v in (2050, -1, 2015) do (
         if "%VSDIR%"=="" (
-          if exist "C:\Program Files (x86^)\Microsoft Visual Studio\%%v\Community\" (
+          if exist "C:\Program Files (x86)\Microsoft Visual Studio\%%v\Community\" (
               set VSDIR=C:\Program Files (x86^)\Microsoft Visual Studio\%%v\Community
           )
         )


### PR DESCRIPTION
Add support for VS Build Tools (2019, 2022, and beyond).

https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022

These are more commonly used to build windows apps from the CLI or during CI pipelines.  In short, this is just the compiler toolchain, build environments, and system headers without the IDE.

Includes a fix to the setup.bat along with a git configuration file to avoid modifying line endings when installing or updating bake.

