### PR TITLE
Add amalgamate-path to project.json

### DIFF
--- a/drivers/amalgamate/src/main.c
+++ b/drivers/amalgamate/src/main.c
@@ -324,24 +324,32 @@ void generate(
         target_path = project_obj->generate_path;
     }
 
+    char *output_path;
+    if (project_obj->amalgamate_path) {
+        output_path = ut_asprintf("%s/%s", target_path, project_obj->amalgamate_path);
+        ut_mkdir(output_path);
+    } else {
+        output_path = ut_asprintf("%s", target_path);
+    }
+
     /* Create output file strings & check when they were last modified */
-    char *include_file_out = ut_asprintf("%s/%s.h", target_path, project);
-    char *include_file_tmp = ut_asprintf("%s/%s.h.tmp", target_path, project);
+    char *include_file_out = ut_asprintf("%s/%s.h", output_path, project);
+    char *include_file_tmp = ut_asprintf("%s/%s.h.tmp", output_path, project);
     time_t include_modified = 0;
     if (ut_file_test(include_file_out) == 1) {
         include_modified = ut_lastmodified(include_file_out);
     }
 
-    char *src_file_out = ut_asprintf("%s/%s.c", target_path, project);
-    char *src_file_tmp = ut_asprintf("%s/%s.c.tmp", target_path, project);
+    char *src_file_out = ut_asprintf("%s/%s.c", output_path, project);
+    char *src_file_tmp = ut_asprintf("%s/%s.c.tmp", output_path, project);
     time_t src_modified = 0;
     if (ut_file_test(src_file_out) == 1) {
         src_modified = ut_lastmodified(src_file_out);
     }
 
     /* In case project contains Objective C files */
-    char *m_file_out = ut_asprintf("%s/%s_objc.m", target_path, project);
-    char *m_file_tmp = ut_asprintf("%s/%s_objc.m.tmp", target_path, project);
+    char *m_file_out = ut_asprintf("%s/%s_objc.m", output_path, project);
+    char *m_file_tmp = ut_asprintf("%s/%s_objc.m.tmp", output_path, project);
     time_t m_modified = 0;
     if (ut_file_test(m_file_out) == 1) {
         m_modified = ut_lastmodified(m_file_out);
@@ -489,6 +497,7 @@ void generate(
     free(src_file_tmp);
     free(src_path);
     free(include_path);
+    free(output_path);
 
     ut_rb_free(files_parsed);
     ut_rb_free(objc_files_parsed);

--- a/include/bake/project.h
+++ b/include/bake/project.h
@@ -90,6 +90,7 @@ struct bake_project {
     bool public;            /* Is package public or private */
     bool coverage;          /* Include in coverage analysis (default = true) */
     bool amalgamate;        /* Generate amalgamated source (default = false) */
+    char *amalgamate_path;  /* Output subdirectory project path for amalgamated source (default = .) */
     bool standalone;    /* Copy amalgamated sources from dependencies (default = false) */
     bool recursive;         /* Is this project recursively built */
     ut_ll use;              /* Project dependencies */

--- a/src/project.c
+++ b/src/project.c
@@ -376,6 +376,9 @@ int16_t bake_project_parse_value(
         if (!strcmp(member, "amalgamate")) {
            ut_try (bake_json_set_boolean(&p->amalgamate, member, v), NULL);
         } else
+        if (!strcmp(member, "amalgamate_path") || !strcmp(member, "amalgamate-path")) {
+           ut_try (bake_json_set_string(&p->amalgamate_path, member, v), NULL);
+        } else
         if (!strcmp(member, "standalone") || !strcmp(member, "standalone")) {
            ut_try (bake_json_set_boolean(&p->standalone, member, v), NULL);
         } else                


### PR DESCRIPTION
Add field amalgamate-path to project.json to configure the output subdirectory of project path for the amalgamated source and header.