### PR TITLE
Fix warning about inverted calloc arguments

### DIFF
--- a/drivers/test/src/cdiff.c
+++ b/drivers/test/src/cdiff.c
@@ -694,7 +694,7 @@ void cdiff_file_write(
 
     /* If no element specified for writing, write to new text element. */
     if (!file->cur && file->isNew) {
-        cdiff_elem *el = calloc(sizeof(cdiff_elem), 1);
+        cdiff_elem *el = calloc(1, sizeof(cdiff_elem));
         el->kind = CDIFF_TEXT;
         el->body = ut_strbuf_get(&file->writeBuffer);
         if (!file->elements) {
@@ -730,4 +730,3 @@ void cdiff_file_dedent(
     ut_assert(file->indent != 0, "too many dedents");
     file->indent --;
 }
-


### PR DESCRIPTION
When running setup.sh, I got this nice warning;
```drivers/test/src/cdiff.c: In function ‘cdiff_file_write’:
drivers/test/src/cdiff.c:697:40: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  697 |         cdiff_elem *el = calloc(sizeof(cdiff_elem), 1);
      |                                        ^~~~~~~~~~
drivers/test/src/cdiff.c:697:40: note: earlier argument should specify number of elements, later size of each element
```
This one-line PR fixes the argument order.