### PR TITLE
Removes one (1) call to ut_getenv in the main function 

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1347,8 +1347,9 @@ void bake_message(
 }
 
 int main(int argc, const char *argv[]) {
-    if (ut_getenv("BAKE_ENVIRONMENT")) {
-        env = ut_getenv("BAKE_ENVIRONMENT");
+    char* bake_environment = ut_getenv("BAKE_ENVIRONMENT");
+    if (bake_environment) {
+        env = bake_environment;
     }
 
     srand (time(NULL));


### PR DESCRIPTION
This might improve performance by up to 0.001% (!)

(Sorry for the micro PR, this just bothered me when i was starting to read the code)