### PR TITLE
Fix artefact target name for windows

### DIFF
--- a/drivers/lang/c/src/gcc/driver.c
+++ b/drivers/lang/c/src/gcc/driver.c
@@ -746,7 +746,7 @@ char* gcc_artefact_name(
         if (is_emcc()) {
             result = ut_asprintf("%s.js", id);
         } else {
-            result = ut_strdup(id);
+            result = ut_asprintf("%s"UT_OS_BIN_EXT, id);
         }
     }
 


### PR DESCRIPTION
Im trying to run the tests of flecs but it does not work under Windows 11 with msys.
That is the output:
```bash
~/code/flecs master !1 > bakebin run test/core --debug -- -j 4

..de\bake\src\main.c:1383: bake 2.5.0
..de\bake\src\main.c:1383: | cmd  C:\msys64\home\akuna\code\zig-bake\zig-out\bake\bakebin.exe run test/core --debug -- -j 4
..de\bake\src\main.c:1385: | cwd  C:\msys64\home\akuna\code\flecs
..de\bake\src\main.c:1386: +
..de\bake\src\main.c:1414: init
..de\bake\src\main.c:1414: | configuration debug
..de\bake\src\main.c:1415: | environment default
..de\bake\src\main.c:1419: | path test/core
..de\bake\src\main.c:1420: | action run
..de\bake\src\main.c:1421: +
..\bake\src\config.c:545 : config
..\bake\src\config.c:545 : | debug configuration not found in bake settings file, using defaults
..de\bake\src\main.c:1478: +
..\bake\src\config.c:667 : environment
..\bake\src\config.c:667 : | set 'BAKE_HOME' to 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake'
..\bake\src\config.c:667 : | set 'BAKE_TARGET' to 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake\x64-Mingw\debug'
..\bake\src\config.c:667 : | set 'BAKE_PLATFORM' to 'x64-Mingw'
..\bake\src\config.c:667 : | set 'PATH' to 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake\lib;C:/msys64/home/akuna/code/zig-bake/zig-out/bake\x64-Mingw\debug\lib;C:/msys64/home/akuna/code/zig-bake/zig-out/bake\x64-Mingw\debug\bin;C:\msys64\home\akuna\bake;C:\msys64\home\akuna\code\zig-bake\zig-out\bake;C:\msys64\home\akuna\.local\bin;C:\msys64\home\akuna\.local\share\zinit\polaris\bin;C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\usr\bin;C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\msys64\usr\bin\site_perl;C:\msys64\usr\bin\vendor_perl;C:\msys64\usr\bin\core_perl;C:\msys64\home\akuna\.local\share\zinit\plugins\z-shell---zsh-diff-so-fancy\bin'
..\bake\src\config.c:667 : | set 'CLASSPATH' to 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake\java'
..\bake\src\config.c:669 : +
..\bake\src\config.c:672 : compiler
..\bake\src\config.c:672 : | CC=zig cc
..\bake\src\config.c:673 : | CXX=(null)
..\bake\src\config.c:674 : +
..\bake\src\config.c:677 : configuration
..\bake\src\config.c:677 : | set 'symbols' to 'true'
..\bake\src\config.c:678 : | set 'debug' to 'true'
..\bake\src\config.c:679 : | set 'optimizations' to 'false'
..\bake\src\config.c:680 : | set 'coverage' to 'false'
..\bake\src\config.c:681 : | set 'strict' to 'false'
..\bake\src\config.c:682 : | set 'sanitize-memory' to 'false'
..\bake\src\config.c:683 : | set 'sanitize-thread' to 'false'
..\bake\src\config.c:684 : | set 'sanitize-undefined' to 'false'
..\bake\src\config.c:685 : | set 'loop-test' to 'false'
..\bake\src\config.c:686 : | set 'assembly' to 'false'
..\bake\src\config.c:687 : +
..ke\util\src\load.c:465 : first time locating 'bake.lang.c'
..ke\util\src\load.c:561 : try locating binary for 'bake.lang.c'
..ke\util\src\load.c:321 : test for shared library file 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake\lib\bake_lang_c.dll'
..\bake\src\driver.c:1039: driver 'lang.c' loaded (package = 'bake.lang.c')
..\bake\src\driver.c:802 : lang.c: init
..ke\util\src\load.c:465 : first time locating 'bake.test'
..ke\util\src\load.c:561 : try locating binary for 'bake.test'
..ke\util\src\load.c:321 : test for shared library file 'C:/msys64/home/akuna/code/zig-bake/zig-out/bake\lib\bake_test.dll'
..\bake\src\driver.c:1039: driver 'test' loaded (package = 'bake.test')
..\bake\src\driver.c:802 : lang.c: init
..ode\bake\src\run.c:602 : starting app 'core'
..ode\bake\src\run.c:603 :   executable = 'bin\x64-Mingw-debug\core'
..ode\bake\src\run.c:604 :   project path = 'test/core'
..ode\bake\src\run.c:605 :   project kind = 'application'
..ode\bake\src\run.c:606 :   interactive = 'false'
..ode\bake\src\run.c:621 : starting process 'bin\x64-Mingw-debug\core'
..til\src\win\proc.c:61  : C:\msys64\home\akuna\code\zig-bake\zig-out\bake\bakebin.exe "C:\msys64\home\akuna\code\zig-bake\zig-out\bake\bakebin.exe" . -r
...
..de\bake\src\rule.c:304 : | | | core does not exist for ARTEFACT, rebuilding
..de\bake\src\rule.c:339 : | | | .\bin\x64-Mingw-debug\core
..til\src\win\proc.c:61  : | | | C:\msys64\home\akuna\.local\bin\zig.exe "C:\msys64\home\akuna\.local\bin\zig.exe" cc -Wall -O0 .bake_cache\x64-Mingw-debug\obj\Add.o .bake_cache\x64-Mingw-debug\obj\Clone.o .bake_cache\x64-Mingw-debug\obj\Commands.o .bake_cache\x64-Mingw-debug\obj\ComponentLifecycle.o .bake_cache\x64-Mingw-debug\obj\Count.o .bake_cache\x64-Mingw-debug\obj\Delete.o .bake_cache\x64-Mingw-debug\obj\Each.o .bake_cache\x64-Mingw-debug\obj\Entity.o .bake_cache\x64-Mingw-debug\obj\Error.o .bake_cache\x64-Mingw-debug\obj\Event.o .bake_cache\x64-Mingw-debug\obj\Get_component.o .bake_cache\x64-Mingw-debug\obj\GlobalComponentIds.o .bake_cache\x64-Mingw-debug\obj\Has.o .bake_cache\x64-Mingw-debug\obj\Hierarchies.o .bake_cache\x64-Mingw-debug\obj\Id.o .bake_cache\x64-Mingw-debug\obj\Internals.o .bake_cache\x64-Mingw-debug\obj\Iter.o .bake_cache\x64-Mingw-debug\obj\Lookup.o .bake_cache\x64-Mingw-debug\obj\main.o .bake_cache\x64-Mingw-debug\obj\Monitor.o .bake_cache\x64-Mingw-debug\obj\New.o .bake_cache\x64-Mingw-debug\obj\New_w_Count.o .bake_cache\x64-Mingw-debug\obj\Observer.o .bake_cache\x64-Mingw-debug\obj\ObserverOnSet.o .bake_cache\x64-Mingw-debug\obj\OnDelete.o .bake_cache\x64-Mingw-debug\obj\Pairs.o .bake_cache\x64-Mingw-debug\obj\Poly.o .bake_cache\x64-Mingw-debug\obj\Prefab.o .bake_cache\x64-Mingw-debug\obj\ReadWrite.o .bake_cache\x64-Mingw-debug\obj\Reference.o .bake_cache\x64-Mingw-debug\obj\Remove.o .bake_cache\x64-Mingw-debug\obj\Search.o .bake_cache\x64-Mingw-debug\obj\Set.o .bake_cache\x64-Mingw-debug\obj\SingleThreadStaging.o .bake_cache\x64-Mingw-debug\obj\Singleton.o .bake_cache\x64-Mingw-debug\obj\Sparse.o .bake_cache\x64-Mingw-debug\obj\StackAlloc.o .bake_cache\x64-Mingw-debug\obj\Stresstests.o .bake_cache\x64-Mingw-debug\obj\Table.o .bake_cache\x64-Mingw-debug\obj\Trigger.o .bake_cache\x64-Mingw-debug\obj\TriggerOnAdd.o .bake_cache\x64-Mingw-debug\obj\TriggerOnRemove.o .bake_cache\x64-Mingw-debug\obj\TriggerOnSet.o .bake_cache\x64-Mingw-debug\obj\Type.o .bake_cache\x64-Mingw-debug\obj\Union.o .bake_cache\x64-Mingw-debug\obj\util.o .bake_cache\x64-Mingw-debug\obj\World.o .bake_cache\x64-Mingw-debug\obj\WorldInfo.o -LC:/msys64/home/akuna/code/zig-bake/zig-out/bake\x64-Mingw\debug\lib -LC:/msys64/home/akuna/code/zig-bake/zig-out/bake/lib -lflecs -lbake_test -o .\bin\x64-Mingw-debug\core
..de\bake\src\rule.c:498 : | | +
..e\bake\src\build.c:162 : | +
..de\bake\src\main.c:1591: +
..til\src\win\proc.c:43  : [  throw] SearchPath: failed to locate executable 'bin\x64-Mingw-debug\core' in PATH
[    run] application core [0] 'bin\x64-Mingw-debug\core'
..ode\bake\src\run.c:635 : [  throw] failed to start process 'bin\x64-Mingw-debug\core'
..til\src\win\proc.c:43  : [  error] SearchPath: failed to locate executable 'bin\x64-Mingw-debug\core' in PATH
..ode\bake\src\run.c:635 : [   from] failed to start process 'bin\x64-Mingw-debug\core'
```


It seems that the executable gets created without a file extension:
```
~/code/flecs master !1 > ll test/core/bin/x64-Mingw-debug
Mode  Size Date Modified    Git Name
-a--- 4.8M 2024-11-19 21:12  -I core
-a--- 3.8M 2024-11-19 21:12  -I core.pdb
```



After this patch it worked fine, let me know if I need to test anything else.